### PR TITLE
Fixed Approve Entries

### DIFF
--- a/includes/class-admin-approve-entries.php
+++ b/includes/class-admin-approve-entries.php
@@ -349,7 +349,7 @@ class GravityView_Admin_ApproveEntries {
 
 		$entry = GFAPI::get_entry( $entry_id );
 
-		self::update_approved_meta( $entry[ (string)$approvedcolumn ] );
+		self::update_approved_meta( $entry_id, $entry[ (string)$approvedcolumn ] );
 
 	}
 

--- a/readme.txt
+++ b/readme.txt
@@ -20,6 +20,9 @@ Beautifully display your Gravity Forms entries. Learn more on [GravityView.co](h
 
 == Changelog ==
 
+= 1.7.6.2 =
+Fixed: PHP warning when trying to update an entry with the approved field.
+
 = 1.7.6.1 on May 7 =
 * Fixed: Pagination links not working when a search is performed
 * Fixed: Return false instead of error if updating approved status fails


### PR DESCRIPTION
PHP Warning:  Missing argument 2 for
`GravityView_Admin_ApproveEntries::update_approved_meta()`, called
in `wordpress/wp-content/plugins/gravityview/includes/class-admin-approve-entries.php` on line `352` and defined in
`wordpress/wp-content/plugins/gravityview/includes/class-admin-approve-entries.php` on line `369`