### PR TITLE
Bug/sortable fields

### DIFF
--- a/includes/class-common.php
+++ b/includes/class-common.php
@@ -924,8 +924,6 @@ class GVCommon {
 
 			$blacklist_field_types = apply_filters( 'gravityview_blacklist_field_types', array( 'list', 'textarea' ), null );
 
-			$output .= '<option value="date_created" '. selected( 'date_created', $current, false ).'>'. esc_html__( 'Date Created', 'gravityview' ) .'</option>';
-
 			foreach ( $fields as $id => $field ) {
 				if ( in_array( $field['type'], $blacklist_field_types ) ) {
 					continue;

--- a/includes/class-common.php
+++ b/includes/class-common.php
@@ -961,7 +961,7 @@ class GVCommon {
 			),
 		);
 
-		$fields = array_merge( $date_created, $fields );
+        $fields = $date_created + $fields;
 
 		$blacklist_field_types = apply_filters( 'gravityview_blacklist_field_types', $blacklist, NULL );
 

--- a/readme.txt
+++ b/readme.txt
@@ -21,6 +21,7 @@ Beautifully display your Gravity Forms entries. Learn more on [GravityView.co](h
 == Changelog ==
 
 * Updated: The minimum required version of Gravity Forms is now 1.8.7. **GravityView will be requiring Gravity Forms 1.9 soon.** Please update Gravity Forms if you are running an older version!
+* Fixed: Conflicts with A-Z filter extension and View sorting due to wrong field mapping
 
 = 1.8 on May 26 =
 * View settings have been consolidated to a single location. [Learn more about the new View Settings layout](http://docs.gravityview.co/article/275-view-settings).


### PR DESCRIPTION
Fixed: Conflicts with A-Z filter extension and View sorting due to wrong field mapping

- array_merge was changing field IDs for the sortable fields array
- duplicated “date_created” field