### PR TITLE
Duplicated fields on edit entry

### DIFF
--- a/includes/extensions/edit-entry/class-edit-entry-render.php
+++ b/includes/extensions/edit-entry/class-edit-entry-render.php
@@ -175,13 +175,11 @@ class GravityView_Edit_Entry_Render {
 
         // Multiple Views embedded, don't proceed if nonce fails
         if( $gv_data->has_multiple_views() && ! wp_verify_nonce( $_GET['edit'], self::$nonce_key ) ) {
-            $this->print_scripts();
             return;
         }
 
         // Sorry, you're not allowed here.
         if( false === $this->user_can_edit_entry( true ) ) {
-            $this->print_scripts();
             return;
         }
 
@@ -1166,7 +1164,7 @@ class GravityView_Edit_Entry_Render {
 	    }
 
         // First, remove blacklist
-        foreach ( $fields as $key => &$field ) {
+        foreach ( $fields as $key => $field ) {
             if( in_array( $field->type, $field_type_blacklist ) ) {
                 unset( $fields[ $key ] );
             }
@@ -1183,12 +1181,9 @@ class GravityView_Edit_Entry_Render {
 	        /** @var GF_Field $field */
 	        foreach ( $fields as $field ) {
 
-                if( intval( $configured_field['id'] ) === intval( $field->id ) ){
-
-	                if( $this->user_can_edit_field( $configured_field, false ) ) {
-                        $edit_fields[] = $this->merge_field_properties( $field, $configured_field );
-                    }
-
+                if( intval( $configured_field['id'] ) === intval( $field->id ) && $this->user_can_edit_field( $configured_field, false ) ) {
+                    $edit_fields[] = $this->merge_field_properties( $field, $configured_field );
+                    break;
                 }
 
             }

--- a/readme.txt
+++ b/readme.txt
@@ -22,6 +22,7 @@ Beautifully display your Gravity Forms entries. Learn more on [GravityView.co](h
 
 = =
 * Fixed: Edit Entry link and Delete Entry link in embedded Views go to default view url
+* Fixed: Duplicated fields
 
 = 1.10 on June 26 =
 * Update: Due to the new Edit Entry functionality, GravityView now requires Gravity Forms 1.9 or higher

--- a/readme.txt
+++ b/readme.txt
@@ -22,7 +22,7 @@ Beautifully display your Gravity Forms entries. Learn more on [GravityView.co](h
 
 = =
 * Fixed: Edit Entry link and Delete Entry link in embedded Views go to default view url
-* Fixed: Duplicated fields
+* Fixed: Duplicated fields on the Edit Entry view
 
 = 1.10 on June 26 =
 * Update: Due to the new Edit Entry functionality, GravityView now requires Gravity Forms 1.9 or higher


### PR DESCRIPTION
- if we are not enqueueing css on error, then, no need to print scripts
- by using the &$field on line 1169 we were causing a duplication of
fields because of wrong array reference on the loop of line 1184
(together with the absence of the break; )
@link: http://uk.php.net/manual/en/control-structures.foreach.php -
read the warning message.