### PR TITLE
Remove the validation hook from User Registration Add-on

### DIFF
--- a/includes/class-admin-welcome.php
+++ b/includes/class-admin-welcome.php
@@ -200,6 +200,7 @@ class GravityView_Welcome {
 								<li><strong>DataTables</strong> display entries in a dynamic table with advanced sorting capabilities provided by the <a href="http://datatables.net">DataTables</a> script.</li>
 							</ul>
 						</li>
+                        <li>On the View Configuration metabox, click on the "+Add Field" button to add form fields to the active areas of your View. These are the fields that will be displayed in the frontend.</li>
 					</ol>
 				</div>
 

--- a/includes/extensions/edit-entry/class-edit-entry-render.php
+++ b/includes/extensions/edit-entry/class-edit-entry-render.php
@@ -899,6 +899,11 @@ class GravityView_Edit_Entry_Render {
      */
     function validate() {
 
+        // If using GF User Registration Add-on, remove the validation step, otherwise generates error when updating the entry
+        if ( class_exists( 'GFUser' ) ) {
+            remove_filter( 'gform_validation', array( 'GFUser', 'user_registration_validation' ) );
+        }
+
         /**
          * For some crazy reason, Gravity Forms doesn't validate Edit Entry form submissions.
          * You can enter whatever you want!

--- a/readme.txt
+++ b/readme.txt
@@ -20,6 +20,9 @@ Beautifully display your Gravity Forms entries. Learn more on [GravityView.co](h
 
 == Changelog ==
 
+= =
+* Fixed: Removed User Registration add-on validation when updating an entry
+
 = 1.10.1 on July 2 =
 * Fixed: Edit Entry link and Delete Entry link in embedded Views go to default view url
 * Fixed: Duplicated fields on the Edit Entry view


### PR DESCRIPTION
This is displaying errors when updating entries where the
username/email already exists