### PR TITLE
Refactor how the other_entries field is calculated

### DIFF
--- a/gravityview.php
+++ b/gravityview.php
@@ -14,7 +14,7 @@
  * Plugin Name:       	GravityView
  * Plugin URI:        	http://gravityview.co
  * Description:       	Create directories based on a Gravity Forms form, insert them using a shortcode, and modify how they output.
- * Version:          	1.10.1
+ * Version:          	1.11
  * Author:            	Katz Web Services, Inc.
  * Author URI:        	http://www.katzwebservices.com
  * Text Domain:       	gravityview
@@ -71,7 +71,7 @@ if( is_admin() ) {
  */
 final class GravityView_Plugin {
 
-	const version = '1.10.1';
+	const version = '1.11';
 
 	public static $theInstance;
 

--- a/includes/extensions/edit-entry/class-edit-entry-render.php
+++ b/includes/extensions/edit-entry/class-edit-entry-render.php
@@ -738,7 +738,7 @@ class GravityView_Edit_Entry_Render {
 
         /**
          * change the field value if needed
-         * @since 1.10.2
+         * @since 1.11
          *
          * @param mixed $field_value field value used to populate the input
          * @param object $field Gravity Forms field object ( Class GF_Field )

--- a/includes/extensions/edit-entry/class-edit-entry-user-registration.php
+++ b/includes/extensions/edit-entry/class-edit-entry-user-registration.php
@@ -2,7 +2,7 @@
 /**
  * GravityView Edit Entry - Sync User Registration (when using the GF User Registration Add-on)
  *
- * @since 1.10.2
+ * @since 1.11
  * @package   GravityView
  * @license   GPL2+
  * @author    Katz Web Services, Inc.
@@ -29,14 +29,14 @@ class GravityView_Edit_Entry_User_Registration {
     }
 
 	/**
-	 * @since 1.10.2
+	 * @since 1.11
 	 */
 	public function load() {
 
 	    /**
 	     * If you want to update the user information when an entry is updated
 	     *
-	     * @since 1.10.2
+	     * @since 1.11
 	     * @param boolean $boolean Whether to trigger update on user registration (default: true)
 	     */
         if( apply_filters( 'gravityview/edit_entry/user_registration/trigger_update', true ) ) {
@@ -48,7 +48,7 @@ class GravityView_Edit_Entry_User_Registration {
      *
      * Update the WordPress user profile based on the GF User Registration create feed
      *
-     * @since 1.10.2
+     * @since 1.11
      *
      * @param array $form Gravity Forms form array
      * @param string $entry_id Gravity Forms entry ID
@@ -64,7 +64,7 @@ class GravityView_Edit_Entry_User_Registration {
 	    /**
 	     * Modify the entry details before updating the user
 	     *
-	     * @since 1.10.2
+	     * @since 1.11
 	     * @param array $entry GF entry
 	     * @param array $form GF form
 	     */

--- a/readme.txt
+++ b/readme.txt
@@ -22,6 +22,8 @@ Beautifully display your Gravity Forms entries. Learn more on [GravityView.co](h
 
 = =
 * Fixed: Removed User Registration add-on validation when updating an entry
+* Fixed: Conflicts with the Other Entries field when placing a search:
+    - The filter hook "gravityview/field/other_entries/args" was replaced by "gravityview/field/other_entries/criteria". If you are using this filter please contact the support before updating the plugin so we could help you with the transition.
 
 = 1.10.1 on July 2 =
 * Fixed: Edit Entry link and Delete Entry link in embedded Views go to default view url

--- a/templates/fields/other_entries.php
+++ b/templates/fields/other_entries.php
@@ -17,31 +17,47 @@ if( empty( $created_by ) ) {
 	return;
 }
 
-// Generate the search parameters
-$args = array(
-	'id'              => $gravityview_view->getViewId(),
-	'page_size'       => $gravityview_view->getCurrentFieldSetting('page_size'),
-	'search_field'    => 'created_by',
-	'search_value'    => $created_by,
-	'search_operator' => 'is',
+$form_id = $gravityview_view->getFormId();
+
+// Get the settings for the View ID
+$view_settings = gravityview_get_template_settings( $gravityview_view->getViewId() );
+
+$view_settings['page_size'] = $gravityview_view->getCurrentFieldSetting('page_size');
+
+// Prepare paging criteria
+$criteria['paging'] = array(
+    'offset' => 0,
+    'page_size' => $view_settings['page_size']
 );
 
-/**
- * @since 1.7.6
- */
-$args = apply_filters( 'gravityview/field/other_entries/args', $args, $field );
+// Prepare Search Criteria
+$criteria['search_criteria'] = array(
+    'field_filters' => array(
+        array(
+            'key' => 'created_by',
+            'value' => $created_by,
+            'operator' => 'is'
+        )
+    )
+);
+$criteria['search_criteria'] = GravityView_frontend::process_search_only_approved( $view_settings, $criteria['search_criteria'] );
+$criteria['search_criteria']['status'] = apply_filters( 'gravityview_status', 'active', $view_settings );
 
-// Get the entries for the search
-$entries = GravityView_frontend::get_view_entries( $args, $field['form']['id'] );
+/**
+ * Modify the search parameters before the entries are fetched
+ */
+$criteria = apply_filters('gravityview/field/other_entries/criteria', $criteria, $view_settings, $form_id );
+
+$entries = GVCommon::get_entries( $form_id, $criteria );
 
 // Don't show if no entries and the setting says so
-if( empty( $entries['entries'] ) && $gravityview_view->getCurrentFieldSetting('no_entries_hide') ) {
+if( empty( $entries ) && $gravityview_view->getCurrentFieldSetting('no_entries_hide') ) {
 	return;
 }
 
 // If there are search results, get the entry list object
 $list = new GravityView_Entry_List(
-	$entries['entries'],
+	$entries,
 	$gravityview_view->getPostId(),
 	$field['form'],
 	$gravityview_view->getCurrentFieldSetting('link_format'),
@@ -51,3 +67,12 @@ $list = new GravityView_Entry_List(
 
 // Generate and echo the output
 $list->output();
+
+/**
+ * @since 1.7.6
+ * @deprecated since 1.10.2
+ */
+$deprecated = apply_filters( 'gravityview/field/other_entries/args', array(), $field );
+if ( !empty( $deprecated ) ) {
+    _deprecated_function(  'The "gravityview/field/other_entries/args" filter', 'GravityView 1.10.2', 'gravityview/field/other_entries/criteria' );
+}

--- a/templates/fields/other_entries.php
+++ b/templates/fields/other_entries.php
@@ -45,6 +45,12 @@ $criteria['search_criteria']['status'] = apply_filters( 'gravityview_status', 'a
 
 /**
  * Modify the search parameters before the entries are fetched
+ *
+ * @since 1.11
+ *
+ * @param array $criteria Gravity Forms search criteria array, as used by GVCommon::get_entries()
+ * @param array $view_settings Associative array of settings with plugin defaults used if not set by the View
+ * @param int $form_id The Gravity Forms ID
  */
 $criteria = apply_filters('gravityview/field/other_entries/criteria', $criteria, $view_settings, $form_id );
 
@@ -70,9 +76,9 @@ $list->output();
 
 /**
  * @since 1.7.6
- * @deprecated since 1.10.2
+ * @deprecated since 1.11
  */
 $deprecated = apply_filters( 'gravityview/field/other_entries/args', array(), $field );
 if ( !empty( $deprecated ) ) {
-    _deprecated_function(  'The "gravityview/field/other_entries/args" filter', 'GravityView 1.10.2', 'gravityview/field/other_entries/criteria' );
+    _deprecated_function(  'The "gravityview/field/other_entries/args" filter', 'GravityView 1.11', 'gravityview/field/other_entries/criteria' );
 }


### PR DESCRIPTION
Not possible to use “GravityView_frontend::get_view_entries()” as it
gets interferences from the search and other url arguments.