### PR TITLE
Search date_created using UTC time not human time

### DIFF
--- a/includes/widgets/search-widget/class-search-widget.php
+++ b/includes/widgets/search-widget/class-search-widget.php
@@ -353,8 +353,14 @@ class GravityView_Widget_Search extends GravityView_Widget {
 		$curr_end = esc_attr( rgget( 'gv_end' ) );
 
 		if ( ! empty( $curr_start ) && ! empty( $curr_end ) ) {
-			$search_criteria['start_date'] = $curr_start;
-			$search_criteria['end_date'] = $curr_end;
+            /**
+             * date_created is stored in UTC format. Convert search date into UTC
+             * (also used on templates/fields/date_created.php)
+             * @since 1.11.3
+             */
+            $adjust_tz = apply_filters( 'gravityview_date_created_adjust_timezone', true, 'search' );
+			$search_criteria['start_date'] = $adjust_tz ? get_gmt_from_date( $curr_start ) : $curr_start;
+			$search_criteria['end_date'] = $adjust_tz ? get_gmt_from_date( $curr_end ) : $curr_end;
 		}
 
 		// search for a specific entry ID

--- a/includes/widgets/search-widget/class-search-widget.php
+++ b/includes/widgets/search-widget/class-search-widget.php
@@ -358,8 +358,8 @@ class GravityView_Widget_Search extends GravityView_Widget {
          * @since 1.11.3
          */
         $adjust_tz = apply_filters( 'gravityview_date_created_adjust_timezone', true, 'search' );
-        $search_criteria['start_date'] = ( $adjust_tz && !empty( $curr_start ) ) ? get_gmt_from_date( $curr_start ) : '';
-        $search_criteria['end_date'] = ( $adjust_tz  && !empty( $curr_end ) ) ? get_gmt_from_date( $curr_end ) : '';
+        $search_criteria['start_date'] = ( $adjust_tz && !empty( $curr_start ) ) ? get_gmt_from_date( $curr_start ) : $curr_start;
+        $search_criteria['end_date'] = ( $adjust_tz  && !empty( $curr_end ) ) ? get_gmt_from_date( $curr_end ) : $curr_end;
 
 
 		// search for a specific entry ID

--- a/includes/widgets/search-widget/class-search-widget.php
+++ b/includes/widgets/search-widget/class-search-widget.php
@@ -358,8 +358,8 @@ class GravityView_Widget_Search extends GravityView_Widget {
          * @since 1.11.3
          */
         $adjust_tz = apply_filters( 'gravityview_date_created_adjust_timezone', true, 'search' );
-        $search_criteria['start_date'] = $adjust_tz && !empty( $curr_start ) ? get_gmt_from_date( $curr_start ) : $curr_start;
-        $search_criteria['end_date'] = $adjust_tz  && !empty( $curr_end ) ? get_gmt_from_date( $curr_end ) : $curr_end;
+        $search_criteria['start_date'] = ( $adjust_tz && !empty( $curr_start ) ) ? get_gmt_from_date( $curr_start ) : '';
+        $search_criteria['end_date'] = ( $adjust_tz  && !empty( $curr_end ) ) ? get_gmt_from_date( $curr_end ) : '';
 
 
 		// search for a specific entry ID

--- a/includes/widgets/search-widget/class-search-widget.php
+++ b/includes/widgets/search-widget/class-search-widget.php
@@ -352,16 +352,15 @@ class GravityView_Widget_Search extends GravityView_Widget {
 		$curr_start = esc_attr( rgget( 'gv_start' ) );
 		$curr_end = esc_attr( rgget( 'gv_end' ) );
 
-		if ( ! empty( $curr_start ) && ! empty( $curr_end ) ) {
-            /**
-             * date_created is stored in UTC format. Convert search date into UTC
-             * (also used on templates/fields/date_created.php)
-             * @since 1.11.3
-             */
-            $adjust_tz = apply_filters( 'gravityview_date_created_adjust_timezone', true, 'search' );
-			$search_criteria['start_date'] = $adjust_tz ? get_gmt_from_date( $curr_start ) : $curr_start;
-			$search_criteria['end_date'] = $adjust_tz ? get_gmt_from_date( $curr_end ) : $curr_end;
-		}
+        /**
+         * date_created is stored in UTC format. Convert search date into UTC
+         * (also used on templates/fields/date_created.php)
+         * @since 1.11.3
+         */
+        $adjust_tz = apply_filters( 'gravityview_date_created_adjust_timezone', true, 'search' );
+        $search_criteria['start_date'] = $adjust_tz && !empty( $curr_start ) ? get_gmt_from_date( $curr_start ) : $curr_start;
+        $search_criteria['end_date'] = $adjust_tz  && !empty( $curr_end ) ? get_gmt_from_date( $curr_end ) : $curr_end;
+
 
 		// search for a specific entry ID
 		if ( ! empty( $_GET[ 'gv_id' ] ) ) {

--- a/readme.txt
+++ b/readme.txt
@@ -23,6 +23,7 @@ Beautifully display your Gravity Forms entries. Learn more on [GravityView.co](h
 * Fixed: Conflicts with Advanced Filter extension when using the Recent Entries widget
 * Fixed: Sorting icons were being added to List template fields when embedded on the same page as Table templates
 * Fixed: Empty Product fields would show a string (", Qty: , Price:") instead of being empty. This prevented "Hide empty fields" from working
+* Fixed: When searching on the entry create date, date gets converted to GMT before placing the search.
 
 = 1.11.2 on July 22 =
 * Fixed: Bug when comparing empty values with `[gvlogic]`

--- a/readme.txt
+++ b/readme.txt
@@ -23,7 +23,7 @@ Beautifully display your Gravity Forms entries. Learn more on [GravityView.co](h
 * Fixed: Conflicts with Advanced Filter extension when using the Recent Entries widget
 * Fixed: Sorting icons were being added to List template fields when embedded on the same page as Table templates
 * Fixed: Empty Product fields would show a string (", Qty: , Price:") instead of being empty. This prevented "Hide empty fields" from working
-* Fixed: When searching on the entry create date, date gets converted to GMT before placing the search.
+* Fixed: When searching on the Entry Created date, the date used GMT, not blog timezone
 
 = 1.11.2 on July 22 =
 * Fixed: Bug when comparing empty values with `[gvlogic]`

--- a/templates/fields/date_created.php
+++ b/templates/fields/date_created.php
@@ -16,7 +16,7 @@ extract( $gravityview_view->getCurrentField() );
  * @param boolean Use timezone-adjusted datetime? If true, adjusts date based on blog's timezone setting. If false, uses UTC setting.
  * @var string
  */
-$tz_value = apply_filters( 'gravityview_date_created_adjust_timezone', true ) ? get_date_from_gmt( $value ) : $value;
+$tz_value = apply_filters( 'gravityview_date_created_adjust_timezone', true, 'display' ) ? get_date_from_gmt( $value ) : $value;
 
 if( !empty( $field_settings ) && !empty( $field_settings['date_display'] ) && !empty( $tz_value )) {
 


### PR DESCRIPTION
Humans expect to search in their timezone, so before searching, we need
to convert the human time to the UTC time to fetch accurate results