### PR TITLE
Bug/edit entry link datatables

### DIFF
--- a/includes/class-template.php
+++ b/includes/class-template.php
@@ -183,14 +183,14 @@ class GravityView_View extends Gamajo_Template_Loader {
 	}
 
 	/**
-	 * @param null $passed_post
+	 * @param $atts array Associative array to set the data of
 	 *
 	 * @return GravityView_View
 	 */
-	static function getInstance( $passed_post = NULL ) {
+	static function getInstance( $atts = array() ) {
 
 		if( empty( self::$instance ) ) {
-			self::$instance = new self( $passed_post );
+			self::$instance = new self( $atts );
 		}
 
 		return self::$instance;

--- a/includes/extensions/edit-entry/class-edit-entry-render.php
+++ b/includes/extensions/edit-entry/class-edit-entry-render.php
@@ -300,7 +300,7 @@ class GravityView_Edit_Entry_Render {
      * @return mixed
      */
     public function modify_fileupload_settings( $plupload_init, $form_id, $instance ) {
-        if( !self::is_edit_entry() ) {
+        if( ! $this->is_edit_entry() ) {
             return $plupload_init;
         }
 
@@ -1314,7 +1314,7 @@ class GravityView_Edit_Entry_Render {
      */
     function manage_conditional_logic( $has_conditional_logic, $form ) {
 
-        if( ! self::is_edit_entry() ) {
+        if( ! $this->is_edit_entry() ) {
             return $has_conditional_logic;
         }
 

--- a/includes/extensions/edit-entry/class-edit-entry-render.php
+++ b/includes/extensions/edit-entry/class-edit-entry-render.php
@@ -698,7 +698,7 @@ class GravityView_Edit_Entry_Render {
          *
          * @since 1.12.1
          */
-        $override_saved_value = apply_filters( 'gravityview/edit_entry/pre_population/override', false, $field );
+        $override_saved_value = apply_filters( 'gravityview/edit_entry/pre_populate/override', false, $field );
 
         // We're dealing with multiple inputs (e.g. checkbox) but not time or date (as it doesn't store data in input IDs)
         if( isset( $field->inputs ) && is_array( $field->inputs ) && !in_array( $field->type, array( 'time', 'date' ) ) ) {

--- a/includes/extensions/edit-entry/class-edit-entry-render.php
+++ b/includes/extensions/edit-entry/class-edit-entry-render.php
@@ -689,28 +689,39 @@ class GravityView_Edit_Entry_Render {
             $field = GFCommon::add_categories_as_choices( $field, $value );
         }
 
+        /**
+         * Allow the pre-populated value to override saved value
+         * By default, pre-populate mechanism only kicks on empty fields
+         *
+         * @param boolean
+         * @param $field GF_Field object Gravity Forms field object
+         *
+         * @since 1.12.1
+         */
+        $override_saved_value = apply_filters( 'gravityview/edit_entry/pre_population/override', false, $field );
+
         // We're dealing with multiple inputs (e.g. checkbox) but not time or date (as it doesn't store data in input IDs)
         if( isset( $field->inputs ) && is_array( $field->inputs ) && !in_array( $field->type, array( 'time', 'date' ) ) ) {
 
             $field_value = array();
 
             // only accept pre-populated values if the field doesn't have any choice selected.
-            $allow_pre_populated = true;
+            $allow_pre_populated = $field->allowsPrepopulate;
 
-	        foreach ( (array)$field->inputs as $input ) {
+            foreach ( (array)$field->inputs as $input ) {
 
-	            $input_id = strval( $input['id'] );
+                $input_id = strval( $input['id'] );
 
                 if ( ! empty( $this->entry[ $input_id ] ) ) {
-                    $allow_pre_populated = false;
                     $field_value[ $input_id ] =  'post_category' === $field->type ? GFCommon::format_post_category( $this->entry[ $input_id ], true ) : $this->entry[ $input_id ];
+                    $allow_pre_populated = false;
                 }
 
             }
 
-            if( $allow_pre_populated ) {
-                $field_value = $field->get_value_submission( array(), false );
-            }
+            $pre_value = $field->get_value_submission( array(), false );
+
+            $field_value = ! $allow_pre_populated && ! ( $override_saved_value && !empty( $pre_value ) ) ? $field_value : $pre_value;
 
         } else {
 
@@ -720,7 +731,8 @@ class GravityView_Edit_Entry_Render {
             $pre_value = $field->allowsPrepopulate ? GFFormsModel::get_parameter_value( $field->inputName, array(), $field ) : '';
 
             // saved field entry value (if empty, fallback to the pre-populated value, if exists)
-            $field_value = !empty( $this->entry[ $id ] ) ? $this->entry[ $id ] : $pre_value;
+            // or pre-populated value if not empty and set to override saved value
+            $field_value = !empty( $this->entry[ $id ] ) && ! ( $override_saved_value && !empty( $pre_value ) ) ? $this->entry[ $id ] : $pre_value;
 
             // in case field is post_category but inputType is select, multi-select or radio, convert value into array of category IDs.
             if ( 'post_category' === $field->type && !empty( $field_value ) ) {

--- a/includes/extensions/edit-entry/class-edit-entry-render.php
+++ b/includes/extensions/edit-entry/class-edit-entry-render.php
@@ -696,7 +696,7 @@ class GravityView_Edit_Entry_Render {
          * @param boolean
          * @param $field GF_Field object Gravity Forms field object
          *
-         * @since 1.12.1
+         * @since 1.13
          */
         $override_saved_value = apply_filters( 'gravityview/edit_entry/pre_populate/override', false, $field );
 

--- a/includes/extensions/edit-entry/class-edit-entry.php
+++ b/includes/extensions/edit-entry/class-edit-entry.php
@@ -238,9 +238,14 @@ class GravityView_Edit_Entry {
 
         } else {
 
-	        $current_view = gravityview_get_current_view_data( $view_id );
-
-	        $user_edit = isset( $current_view['atts']['user_edit'] ) ? $current_view['atts']['user_edit'] : false;
+            // get user_edit setting
+            if( empty( $view_id ) || $view_id == GravityView_View::getInstance()->getViewId() ) {
+                // if View ID not specified or is the current view
+                $user_edit = GravityView_View::getInstance()->getAtts('user_edit');
+            } else {
+                // in case is specified and not the current view
+                $user_edit = GVCommon::get_template_setting( $view_id, 'user_edit' );
+            }
 
             $current_user = wp_get_current_user();
 

--- a/readme.txt
+++ b/readme.txt
@@ -20,6 +20,9 @@ Beautifully display your Gravity Forms entries. Learn more on [GravityView.co](h
 
 == Changelog ==
 
+= =
+* Fixed: Edit Entry link not showing for non-admins when using the DataTables template
+
 = 1.12 on August 5 =
 * Fixed: Conflicts with Advanced Filter extension when using the Recent Entries widget
 * Fixed: Sorting icons were being added to List template fields when embedded on the same page as Table templates

--- a/readme.txt
+++ b/readme.txt
@@ -22,6 +22,7 @@ Beautifully display your Gravity Forms entries. Learn more on [GravityView.co](h
 
 = =
 * Fixed: Edit Entry link not showing for non-admins when using the DataTables template
+* Added: Allow to override the entry saved value by the dynamic populated value on the Edit Entry view
 
 = 1.12 on August 5 =
 * Fixed: Conflicts with Advanced Filter extension when using the Recent Entries widget


### PR DESCRIPTION
When using DataTables the edit entry link wasn’t showing because the
class GravityView_frontend (used on gravityview_get_current_view_data()
) is not instantiated on DT/AJAX calls.