### PR TITLE
Add filter to override nonces

### DIFF
--- a/includes/extensions/edit-entry/class-edit-entry-render.php
+++ b/includes/extensions/edit-entry/class-edit-entry-render.php
@@ -1468,14 +1468,28 @@ class GravityView_Edit_Entry_Render {
 
         // Verify form submitted for editing single
         if( $this->is_edit_entry_submission() ) {
-            return wp_verify_nonce( $_POST[ self::$nonce_field ], self::$nonce_field );
+            $valid = wp_verify_nonce( $_POST[ self::$nonce_field ], self::$nonce_field );
         }
 
         // Verify
-        if( ! $this->is_edit_entry() ) { return false; }
+        else if( ! $this->is_edit_entry() ) {
+            $valid = false;
+        }
 
-        return wp_verify_nonce( $_GET['edit'], self::$nonce_key );
+        else {
+            $valid = wp_verify_nonce( $_GET['edit'], self::$nonce_key );
+        }
 
+        /**
+         * Override nonce validation
+         * @since 1.13
+         *
+         * @param int|boolean $valid False if invalid; 1 or 2 when nonce was generated
+         * @param string $nonce_field Key used when validating submissions. Default: is_gv_edit_entry
+         */
+        $valid = apply_filters( 'gravityview/edit_entry/verify_nonce', $valid, self::$nonce_field );
+
+        return $valid;
     }
 
 

--- a/readme.txt
+++ b/readme.txt
@@ -20,6 +20,8 @@ Beautifully display your Gravity Forms entries. Learn more on [GravityView.co](h
 
 == Changelog ==
 
+* Added: `gravityview/edit_entry/verify_nonce` filter to override nonce validation in Edit Entry
+
 = 1.12 on August 5 =
 * Fixed: Conflicts with Advanced Filter extension when using the Recent Entries widget
 * Fixed: Sorting icons were being added to List template fields when embedded on the same page as Table templates


### PR DESCRIPTION
People want to allow adding links in emails that don't have expiration
dates. This allows users to override nonce validation by using

```
add_filter( 'gravityview/edit_entry/verify_nonce', '__return_true' );
```

See https://secure.helpscout.net/conversation/111478611/3074/