### PR TITLE
Fix theme conflicts when themes have shortcode pre-processors

### DIFF
--- a/includes/class-template.php
+++ b/includes/class-template.php
@@ -765,6 +765,7 @@ class GravityView_View extends Gamajo_Template_Loader {
 	public function render_widget_hooks( $view_id ) {
 
 		if( empty( $view_id ) || 'single' == gravityview_get_context() ) {
+			do_action( 'gravityview_log_debug', __METHOD__ . ' - Not rendering widgets; single entry' );
 			return;
 		}
 
@@ -788,7 +789,10 @@ class GravityView_View extends Gamajo_Template_Loader {
 		}
 
 		// Prevent being called twice
-		if( did_action( $zone.'_'.$view_id.'_widgets' ) ) { return; }
+		if( did_action( $zone.'_'.$view_id.'_widgets' ) ) {
+			do_action( 'gravityview_log_debug', sprintf( '%s - Not rendering %s; already rendered', __METHOD__ , $zone.'_'.$view_id.'_widgets' ) );
+			return;
+		}
 
 		// TODO Convert to partials
 		?>
@@ -815,8 +819,14 @@ class GravityView_View extends Gamajo_Template_Loader {
 		</div>
 
 		<?php
-		// Prevent being called twice
-		do_action( $zone.'_'.$view_id.'_widgets' );
+
+		/**
+		 * Prevent widgets from being called twice.
+		 * Checking for loop_start prevents themes and plugins that pre-process shortcodes from triggering the action before displaying. Like, ahem, the Divi theme and WordPress SEO plugin
+		 */
+		if( did_action( 'loop_start' ) ) {
+			do_action( $zone.'_'.$view_id.'_widgets' );
+		}
 	}
 
 }

--- a/includes/extensions/edit-entry/class-edit-entry-render.php
+++ b/includes/extensions/edit-entry/class-edit-entry-render.php
@@ -642,7 +642,7 @@ class GravityView_Edit_Entry_Render {
      */
     public function render_form_buttons() {
         ob_start();
-        include_once( GravityView_Edit_Entry::$file .'/partials/form-buttons.php');
+        include( GravityView_Edit_Entry::$file .'/partials/form-buttons.php');
         return ob_get_clean();
     }
 


### PR DESCRIPTION
* Checking for loop_start prevents themes and plugins that pre-process
shortcodes from triggering the action before displaying. Like, ahem,
the Divi theme and WordPress SEO plugin
* Use `include()` instead of `include_once()` to fix pre-processing
issue

Fixes #488