### PR TITLE
Fix/merge tags

### DIFF
--- a/includes/class-gravityview-merge-tags.php
+++ b/includes/class-gravityview-merge-tags.php
@@ -67,10 +67,6 @@ class GravityView_Merge_Tags {
 			}
 		}
 
-		if ( empty( $form ) || empty( $entry ) ) {
-			return self::_gform_replace_merge_tags( $text );
-		}
-
 		return GFCommon::replace_variables( $text, $form, $entry, false, false, false, "html");
 	}
 

--- a/readme.txt
+++ b/readme.txt
@@ -20,6 +20,9 @@ Beautifully display your Gravity Forms entries. Learn more on [gravityview.co](h
 
 == Changelog ==
 
+= 1.15.1 =
+* Fixed: Some Gravity Forms weren't working like `{embed_post:post_title}`
+
 = 1.15 on October 15 =
 * Added: `{get}` Merge Tag that allows passing data via URL to be safely displayed in Merge Tags. [Learn how this works](http://docs.gravityview.co/article/314-the-get-merge-tag).
 	- Example: When adding `?first-name=Floaty` to a URL, the Custom Content `My name is {get:first-name}` would be replaced with `My name is Floaty`


### PR DESCRIPTION
Fixed: Some Gravity Forms weren't working like `{embed_post:post_title}`